### PR TITLE
Require net/http

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    check-sitemap (0.3.0)
+    check-sitemap (0.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -38,4 +38,4 @@ DEPENDENCIES
   rspec (~> 3.7)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/check_sitemap/check_url.rb
+++ b/lib/check_sitemap/check_url.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 class CheckSitemap::CheckURL
 
   def self.call(url)

--- a/lib/check_sitemap/version.rb
+++ b/lib/check_sitemap/version.rb
@@ -1,3 +1,3 @@
 module CheckSitemap
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
Resolving error by requiring `net/http`. Bump version to 0.3.1